### PR TITLE
Support Scaffeine Cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,17 +74,29 @@ import crystailx.scalaflagr.cache.inmemory._
 val service = FlagrService(client, InMemoryCache())
 ```
 
-#### Redis Cache (Scredis)
+#### Scredis Cache
 ```sbt
 libraryDependencies += "io.github.crystailx" %% "scalaflagr-cache-scredis" % scalaflagrVersion
 ```
 ```scala
-import crystailx.scalaflagr.cache.redis._
+import crystailx.scalaflagr.cache.scredis._
 import scredis.RedisCluster
 import scala.concurrent.ExecutionContext.Implicits.global
 
 val cluster = RedisCluster()
 val service = FlagrService(client, RedisCache(cluster))
+```
+
+#### Scaffeine Cache
+```sbt
+libraryDependencies += "io.github.crystailx" %% "scalaflagr-cache-scaffeine" % scalaflagrVersion
+```
+```scala
+import crystailx.scalaflagr.cache.scaffeine._
+import com.github.blemale.scaffeine.Scaffeine
+
+val cacher = ScaffeineAsyncLoadingCache.builder(Scaffeine()).buildAsyncFuture
+val service = FlagrService(client, cacher)
 ```
 
 ### Supported JSON Libraries
@@ -138,7 +150,7 @@ import akka.util.ByteString
 import com.softwaremill.sttp.SttpBackend
 import com.softwaremill.sttp.akkahttp.AkkaHttpBackend
 import crystailx.scalaflagr.auth.BasicAuthConfig
-import crystailx.scalaflagr.cache.redis.{ RedisCache, _ }
+import crystailx.scalaflagr.cache.scredis.{ RedisCache, _ }
 import crystailx.scalaflagr.cache.simpleCacheKey
 import crystailx.scalaflagr.client.sttp.SttpHttpClient
 import crystailx.scalaflagr.data._

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val scala212 = "2.12.17"
 lazy val scala211 = "2.11.12"
 lazy val supportedScalaVersions = Seq(scala213, scala212 /*, scala211*/ )
 ThisBuild / organization := "io.github.crystailx"
-ThisBuild / version := "1.3.0"
+ThisBuild / version := "1.4.0"
 ThisBuild / scalaVersion := scala213
 ThisBuild / crossScalaVersions := supportedScalaVersions
 ThisBuild / trackInternalDependencies := TrackLevel.TrackAlways
@@ -83,10 +83,16 @@ lazy val jsonJackson = (project in file("scalaflagr-json-jackson"))
   .settings(libraryDependencies ++= Dependencies.jackson)
   .dependsOn(coreWithTest)
 
-lazy val redisCache = (project in file("scalaflagr-cache-scredis"))
+lazy val scredisCache = (project in file("scalaflagr-cache-scredis"))
   .settings(name := "scalaflagr-cache-scredis")
   .settings(moduleSettings)
   .settings(libraryDependencies ++= Dependencies.redis)
+  .dependsOn(core)
+
+lazy val scaffeineCache = (project in file("scalaflagr-cache-scaffeine"))
+  .settings(name := "scalaflagr-cache-scaffeine")
+  .settings(moduleSettings)
+  .settings(libraryDependencies ++= Dependencies.scaffeine)
   .dependsOn(core)
 
 lazy val root = (project in file("."))
@@ -95,4 +101,14 @@ lazy val root = (project in file("."))
     crossScalaVersions := Nil,
     update / aggregate := false
   )
-  .aggregate(core, sttp1Client, catsEffect, twitterEffect, jsonCirce, jsonPlay, jsonJackson, redisCache)
+  .aggregate(
+    core,
+    sttp1Client,
+    catsEffect,
+    twitterEffect,
+    jsonCirce,
+    jsonPlay,
+    jsonJackson,
+    scredisCache,
+    scaffeineCache
+  )

--- a/examples/sttp1-circe-scredis-example/build.sbt
+++ b/examples/sttp1-circe-scredis-example/build.sbt
@@ -3,7 +3,7 @@ version := "1.0.0"
 scalaVersion := "2.13.10"
 name := "sttp-circe-scredis-example"
 
-val scalaflagrVersion = "1.3.0-SNAPSHOT"
+val scalaflagrVersion = "1.3.1-SNAPSHOT"
 val sttp1Version = "1.7.2"
 val akkaStreamVersion = "2.7.0"
 resolvers +=

--- a/examples/sttp1-circe-scredis-example/src/main/scala/Service.scala
+++ b/examples/sttp1-circe-scredis-example/src/main/scala/Service.scala
@@ -7,7 +7,7 @@ import crystailx.scalaflagr.cache.simpleCacheKey
 import crystailx.scalaflagr.client.sttp.SttpHttpClient
 import crystailx.scalaflagr.data._
 import crystailx.scalaflagr.json.circe._
-import crystailx.scalaflagr.cache.redis._
+import crystailx.scalaflagr.cache.scredis._
 import crystailx.scalaflagr.{ FlagrClient, FlagrConfig, FlagrService }
 import scredis.protocol.AuthConfig
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,6 +10,7 @@ object Dependencies {
   private val catsVersion = "2.8.0"
   private val twitterVersion = "22.7.0"
   private val redisVersion = "2.4.3"
+  private val scaffeineVersion = "5.2.1"
   private val playJsonVersion = "2.9.3"
   private val jacksonVersion = "2.13.4"
   private val scalatestVersion = "3.2.14"
@@ -57,6 +58,10 @@ object Dependencies {
 
   def redis: Seq[ModuleID] = Seq(
     "com.github.scredis" %% "scredis" % redisVersion
+  )
+
+  def scaffeine: Seq[ModuleID] = Seq(
+    "com.github.blemale" %% "scaffeine" % scaffeineVersion
   )
 
   def test: Seq[ModuleID] =

--- a/scalaflagr-cache-scaffeine/src/main/scala/crystailx/scalaflagr/cache/scaffeine/ScaffeineAsyncCache.scala
+++ b/scalaflagr-cache-scaffeine/src/main/scala/crystailx/scalaflagr/cache/scaffeine/ScaffeineAsyncCache.scala
@@ -1,0 +1,25 @@
+package crystailx.scalaflagr.cache.scaffeine
+
+import com.github.blemale.scaffeine.AsyncCache
+import crystailx.scalaflagr.cache.Cacher
+import crystailx.scalaflagr.data.EvalResult
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+case class ScaffeineAsyncCache[K](
+  underlying: AsyncCache[K, EvalResult]
+)(implicit ec: ExecutionContext)
+    extends Cacher[K, Future] {
+
+  override def set(key: K, evalResult: EvalResult): Future[Unit] =
+    Future(underlying.put(key, Future(evalResult)))
+
+  override def get(key: K): Future[Option[EvalResult]] =
+    Future
+      .sequence(Option.option2Iterable(underlying.getIfPresent(key)))
+      .map(_.headOption)
+
+  override def invalidate(key: K): Future[Unit] = Future(underlying.synchronous().invalidate(key))
+
+  override def invalidateAll(): Future[Unit] = Future(underlying.synchronous().invalidateAll())
+}

--- a/scalaflagr-cache-scaffeine/src/main/scala/crystailx/scalaflagr/cache/scaffeine/ScaffeineAsyncLoadingCache.scala
+++ b/scalaflagr-cache-scaffeine/src/main/scala/crystailx/scalaflagr/cache/scaffeine/ScaffeineAsyncLoadingCache.scala
@@ -1,0 +1,66 @@
+package crystailx.scalaflagr.cache.scaffeine
+
+import com.github.blemale.scaffeine.{ AsyncLoadingCache, Scaffeine }
+import crystailx.scalaflagr.FlagrClient
+import crystailx.scalaflagr.cache.Cacher
+import crystailx.scalaflagr.data.{ EvalContext, EvalResult, FlagrContext }
+import crystailx.scalaflagr.effect.{ Applicative, Functor }
+import crystailx.scalaflagr.json.{ Decoder, Encoder }
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+case class ScaffeineAsyncLoadingCache[K] private (
+  underlying: AsyncLoadingCache[K, EvalResult]
+)(implicit ec: ExecutionContext)
+    extends Cacher[K, Future] {
+
+  override def set(key: K, evalResult: EvalResult): Future[Unit] =
+    Future(underlying.put(key, Future(evalResult)))
+
+  override def get(key: K): Future[Option[EvalResult]] =
+    underlying.get(key).map(Option.apply)
+
+  override def invalidate(key: K): Future[Unit] = Future(underlying.synchronous().invalidate(key))
+
+  override def invalidateAll(): Future[Unit] = Future(underlying.synchronous().invalidateAll())
+
+}
+
+object ScaffeineAsyncLoadingCache {
+  import crystailx.scalaflagr.api.evaluate
+
+  case class ScaffeineAsyncLoadingCacheBuilder[F[_]](builder: Scaffeine[Any, Any])(implicit
+    ec: ExecutionContext,
+    client: FlagrClient[F],
+    functor: Functor[F],
+    encoder: Encoder[EvalContext],
+    decoder: Decoder[EvalResult]
+  ) {
+
+    private lazy val evaluation = (context: FlagrContext) =>
+      client.execute(evaluate(context.toEvalContext))
+
+    def buildAsync(implicit handler: AsyncHandler[F]): ScaffeineAsyncLoadingCache[FlagrContext] =
+      ScaffeineAsyncLoadingCache(
+        builder.buildAsync[FlagrContext, EvalResult]((context: FlagrContext) =>
+          handler(evaluation(context))
+        )
+      )
+
+    def buildAsyncFuture(implicit
+      handler: AsyncFutureHandler[F]
+    ): ScaffeineAsyncLoadingCache[FlagrContext] =
+      ScaffeineAsyncLoadingCache(
+        builder.buildAsyncFuture[FlagrContext, EvalResult](context => handler(evaluation(context)))
+      )
+  }
+
+  def builder[F[_]](builder: Scaffeine[Any, Any])(implicit
+    ec: ExecutionContext,
+    client: FlagrClient[F],
+    functor: Functor[F],
+    encoder: Encoder[EvalContext],
+    decoder: Decoder[EvalResult]
+  ): ScaffeineAsyncLoadingCacheBuilder[F] = ScaffeineAsyncLoadingCacheBuilder(builder)
+
+}

--- a/scalaflagr-cache-scaffeine/src/main/scala/crystailx/scalaflagr/cache/scaffeine/ScaffeineCache.scala
+++ b/scalaflagr-cache-scaffeine/src/main/scala/crystailx/scalaflagr/cache/scaffeine/ScaffeineCache.scala
@@ -1,0 +1,22 @@
+package crystailx.scalaflagr.cache.scaffeine
+
+import com.github.blemale.scaffeine.Cache
+import crystailx.scalaflagr.cache.Cacher
+import crystailx.scalaflagr.data.EvalResult
+import crystailx.scalaflagr.effect.Applicative
+
+case class ScaffeineCache[K, F[_]](
+  underlying: Cache[K, EvalResult]
+)(implicit applicative: Applicative[F])
+    extends Cacher[K, F] {
+
+  override def set(key: K, evalResult: EvalResult): F[Unit] =
+    applicative.pure(underlying.put(key, evalResult))
+
+  override def get(key: K): F[Option[EvalResult]] =
+    applicative.pure(underlying.getIfPresent(key))
+
+  override def invalidate(key: K): F[Unit] = applicative.pure(underlying.invalidate(key))
+
+  override def invalidateAll(): F[Unit] = applicative.pure(underlying.invalidateAll())
+}

--- a/scalaflagr-cache-scaffeine/src/main/scala/crystailx/scalaflagr/cache/scaffeine/ScaffeineLoadingCache.scala
+++ b/scalaflagr-cache-scaffeine/src/main/scala/crystailx/scalaflagr/cache/scaffeine/ScaffeineLoadingCache.scala
@@ -1,0 +1,45 @@
+package crystailx.scalaflagr.cache.scaffeine
+
+import com.github.blemale.scaffeine.{ LoadingCache, Scaffeine }
+import crystailx.scalaflagr.FlagrClient
+import crystailx.scalaflagr.cache.Cacher
+import crystailx.scalaflagr.data.{ EvalContext, EvalResult, FlagrContext }
+import crystailx.scalaflagr.effect.{ Applicative, Functor }
+import crystailx.scalaflagr.json.{ Decoder, Encoder }
+
+case class ScaffeineLoadingCache[K, F[_]] private (
+  underlying: LoadingCache[K, EvalResult]
+)(implicit applicative: Applicative[F])
+    extends Cacher[K, F] {
+
+  override def set(key: K, evalResult: EvalResult): F[Unit] =
+    applicative.pure(underlying.put(key, evalResult))
+
+  override def get(key: K): F[Option[EvalResult]] =
+    applicative.pure(Option(underlying.get(key)))
+
+  override def invalidate(key: K): F[Unit] = applicative.pure(underlying.invalidate(key))
+
+  override def invalidateAll(): F[Unit] = applicative.pure(underlying.invalidateAll())
+
+}
+
+object ScaffeineLoadingCache {
+  import crystailx.scalaflagr.api.evaluate
+
+  def apply[F[_]](
+    builder: Scaffeine[Any, Any],
+    handler: F[EvalResult] => EvalResult
+  )(implicit
+    applicative: Applicative[F],
+    client: FlagrClient[F],
+    functor: Functor[F],
+    encoder: Encoder[EvalContext],
+    decoder: Decoder[EvalResult]
+  ): ScaffeineLoadingCache[FlagrContext, F] = {
+    val loadingCache = builder.build[FlagrContext, EvalResult]((context: FlagrContext) =>
+      handler(client.execute(evaluate(context.toEvalContext)))
+    )
+    ScaffeineLoadingCache(loadingCache)
+  }
+}

--- a/scalaflagr-cache-scaffeine/src/main/scala/crystailx/scalaflagr/cache/scaffeine/package.scala
+++ b/scalaflagr-cache-scaffeine/src/main/scala/crystailx/scalaflagr/cache/scaffeine/package.scala
@@ -1,0 +1,24 @@
+package crystailx.scalaflagr.cache
+
+import crystailx.scalaflagr.data.{ EvalResult, FlagrContext }
+import crystailx.scalaflagr.effect.identity._
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{ Await, Future }
+
+package object scaffeine {
+
+  type AsyncHandler[F[_]] = F[EvalResult] => EvalResult
+  type AsyncFutureHandler[F[_]] = F[EvalResult] => Future[EvalResult]
+
+  implicit val contextAsKey: CacheKeyCreator[FlagrContext] = identity[FlagrContext]
+
+  implicit val identityEvalResultHandler: Identity[EvalResult] => EvalResult = identity
+
+  implicit def futureEvalResultHandler(implicit
+    atMost: Duration = Duration.Inf
+  ): AsyncHandler[Future] = f => Await.result(f, atMost)
+
+  implicit val future2FutureEvalResultHandler: AsyncFutureHandler[Future] =
+    identity[Future[EvalResult]]
+}

--- a/scalaflagr-cache-scaffeine/src/test/scala/crystailx/scalaflagr/cache/scaffeine/CaffeineCacheSpec.scala
+++ b/scalaflagr-cache-scaffeine/src/test/scala/crystailx/scalaflagr/cache/scaffeine/CaffeineCacheSpec.scala
@@ -1,0 +1,108 @@
+package crystailx.scalaflagr.cache.scaffeine
+
+import com.github.blemale.scaffeine._
+import crystailx.scalaflagr.FlagrClient
+import crystailx.scalaflagr.data._
+import crystailx.scalaflagr.effect.identity._
+import org.scalatest.OptionValues._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{ Await, Future }
+
+class CaffeineCacheSpec extends AnyFlatSpec with Matchers {
+
+  import TestData._
+
+  it must "create Scaffeine cache" in {
+    val cache: Cache[FlagrContext, EvalResult] =
+      Scaffeine().maximumSize(2L).build()
+    val cacher = ScaffeineCache(cache)
+    cacher.set(key1, value1)
+    cacher.get(key1).value mustBe value1
+    cacher.underlying.asMap() must have size 1
+    cacher.set(key2, value2)
+    cacher.get(key2).value mustBe value2
+    cacher.underlying.asMap() must have size 2
+    cacher.set(key3, value3)
+    cacher.get(key3).value mustBe value3
+    Await.result(Future(Thread.sleep(500)), 1.second)
+    cacher.get(key1) mustBe empty
+    cacher.underlying.asMap() must have size 2
+  }
+
+  it must "create Scaffeine loading cache" in {
+    implicit val client: FlagrClient[Identity] = new FlagrClient[Identity](identityHttpClient)
+    val cacher = ScaffeineLoadingCache(Scaffeine().maximumSize(1L), identityEvalResultHandler)
+    cacher.get(key1).value mustBe value1
+    cacher.underlying.asMap() must have size 1
+    cacher.get(key2).value mustBe value2
+    Await.result(Future(Thread.sleep(500)), 1.second)
+    val underlyingMap = cacher.underlying.asMap()
+    underlyingMap must have size 1
+    underlyingMap.keys must contain only key2
+  }
+
+  it must "create Scaffeine async cache" in {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    val cache: AsyncCache[FlagrContext, Identity[EvalResult]] =
+      Scaffeine().maximumSize(1L).buildAsync[FlagrContext, Identity[EvalResult]]()
+    val cacher = ScaffeineAsyncCache(cache)
+    noException must be thrownBy Await.result(cacher.set(key1, value1), 500.millis)
+    Await.result(Future(Thread.sleep(500 * 5)), 5.second)
+    Await.result(cacher.get(key1), 500.millis).value mustBe value1
+    cacher.underlying.underlying.asMap() must have size 1
+    noException must be thrownBy Await.result(cacher.set(key2, value2), 500.millis)
+    Await.result(cacher.get(key2), 500.millis).value mustBe value2
+    noException must be thrownBy Await.result(cacher.set(key3, value3), 500.millis)
+    Await.result(cacher.get(key3), 500.millis).value mustBe value3
+    Await.result(Future(Thread.sleep(500)), 1.second)
+    val underlyingMap = cacher.underlying.underlying.asMap()
+    underlyingMap must have size 1
+    underlyingMap mustNot contain key key1
+  }
+
+  it must "create Scaffeine async loading cache" in {
+    implicit val client: FlagrClient[Future] = new FlagrClient[Future](futureHttpClient)
+    import crystailx.scalaflagr.effect._
+    val cacher = ScaffeineAsyncLoadingCache.builder(Scaffeine().maximumSize(2L)).buildAsync
+    Await.result(cacher.set(key1, value1), 500.millis)
+    Await.result(cacher.get(key1), 500.millis).value mustBe value1
+    cacher.underlying.underlying.asMap() must have size 1
+    Await.result(cacher.set(key2, value2), 500.millis)
+    Await.result(cacher.get(key2), 500.millis).value mustBe value2
+    cacher.underlying.underlying.asMap() must have size 2
+    Await.result(cacher.set(key3, value3), 500.millis)
+    Await.result(cacher.get(key3), 500.millis).value mustBe value3
+    Await.result(Future(Thread.sleep(500)), 1.second)
+    val underlyingMap = cacher.underlying.underlying.asMap()
+    underlyingMap must have size 2
+    underlyingMap mustNot contain key key2
+  }
+
+  it must "create Scaffeine future async loading cache" in {
+    import scala.concurrent.ExecutionContext.Implicits.global
+    implicit val client: FlagrClient[Future] = new FlagrClient[Future](futureHttpClient)
+    val cacher = ScaffeineAsyncLoadingCache.builder(Scaffeine().maximumSize(2L)).buildAsyncFuture
+    val key1 = BasicContext("flag1")
+    val value1 = EvalResult(flagKey = Some("flag1"), timestamp = "", variantAttachment = None)
+    Await.result(cacher.set(key1, value1), 500.millis)
+    Await.result(cacher.get(key1), 500.millis).value mustBe value1
+    cacher.underlying.underlying.asMap() must have size 1
+    val key2 = BasicContext("flag2")
+    val value2 = EvalResult(flagKey = Some("flag2"), timestamp = "", variantAttachment = None)
+    Await.result(cacher.set(key2, value2), 500.millis)
+    Await.result(cacher.get(key2), 500.millis).value mustBe value2
+    cacher.underlying.underlying.asMap() must have size 2
+    val key3 = BasicContext("flag3")
+    val value3 = EvalResult(flagKey = Some("flag3"), timestamp = "", variantAttachment = None)
+    Await.result(cacher.set(key3, value3), 500.millis)
+    Await.result(cacher.get(key3), 500.millis).value mustBe value3
+    Await.result(Future(Thread.sleep(500)), 1.second)
+    val underlyingMap = cacher.underlying.underlying.asMap()
+    underlyingMap must have size 2
+    underlyingMap mustNot contain key key2
+  }
+}

--- a/scalaflagr-cache-scaffeine/src/test/scala/crystailx/scalaflagr/cache/scaffeine/TestData.scala
+++ b/scalaflagr-cache-scaffeine/src/test/scala/crystailx/scalaflagr/cache/scaffeine/TestData.scala
@@ -1,0 +1,69 @@
+package crystailx.scalaflagr.cache.scaffeine
+
+import crystailx.scalaflagr.client.HttpClient
+import crystailx.scalaflagr.data._
+import crystailx.scalaflagr.effect.identity.Identity
+import crystailx.scalaflagr.json.{ Decoder, Encoder }
+import crystailx.scalaflagr.{ FlagrConfig, FlagrRequest }
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+object TestData {
+  val key1: FlagrContext = BasicContext("flag1")
+
+  val value1: EvalResult =
+    EvalResult(flagKey = Some("flag1"), timestamp = "", variantAttachment = None)
+  val key2: FlagrContext = BasicContext("flag2")
+
+  val value2: EvalResult =
+    EvalResult(flagKey = Some("flag2"), timestamp = "", variantAttachment = None)
+  val key3: FlagrContext = BasicContext("flag3")
+
+  val value3: EvalResult =
+    EvalResult(flagKey = Some("flag3"), timestamp = "", variantAttachment = None)
+
+  val identityHttpClient: HttpClient[Identity] = new HttpClient[Identity] {
+    override protected val config: FlagrConfig = FlagrConfig()
+
+    override def send(request: FlagrRequest): Identity[RawValue] =
+      request.body.map(new String(_)) match {
+        case Some(flagKey) => flagKey.getBytes
+        case _             => throw new Exception("Failed to find flag")
+      }
+  }
+
+  val futureHttpClient: HttpClient[Future] = new HttpClient[Future] {
+    override protected val config: FlagrConfig = FlagrConfig()
+
+    override def send(request: FlagrRequest): Future[RawValue] =
+      request.body.map(new String(_)) match {
+        case Some(flagKey) => Future(flagKey.getBytes)
+        case _             => Future.failed(new Exception("Failed to find flag"))
+      }
+  }
+
+  implicit val encoder: Encoder[EvalContext] = {
+    case EvalContext(_, _, _, _, _, Some(flagKey), _, _) => flagKey.getBytes
+    case _                                               => Array.emptyByteArray
+  }
+
+  implicit val decoder: Decoder[EvalResult] = new Decoder[EvalResult] {
+
+    override def decode(value: RawValue): EvalResult =
+      EvalResult(
+        flagKey = Option(value).filter(_.nonEmpty).map(new String(_)),
+        timestamp = "",
+        variantAttachment = None
+      )
+
+    override def decodeSafe(value: RawValue): Either[Throwable, EvalResult] =
+      Right(
+        EvalResult(
+          flagKey = Option(value).filter(_.nonEmpty).map(new String(_)),
+          timestamp = "",
+          variantAttachment = None
+        )
+      )
+  }
+}

--- a/scalaflagr-cache-scredis/src/main/scala/crystailx/scalaflagr/cache/scredis/RedisCache.scala
+++ b/scalaflagr-cache-scredis/src/main/scala/crystailx/scalaflagr/cache/scredis/RedisCache.scala
@@ -1,4 +1,4 @@
-package crystailx.scalaflagr.cache.redis
+package crystailx.scalaflagr.cache.scredis
 
 import crystailx.scalaflagr.cache.Cacher
 import crystailx.scalaflagr.data.EvalResult

--- a/scalaflagr-cache-scredis/src/main/scala/crystailx/scalaflagr/cache/scredis/package.scala
+++ b/scalaflagr-cache-scredis/src/main/scala/crystailx/scalaflagr/cache/scredis/package.scala
@@ -2,9 +2,9 @@ package crystailx.scalaflagr.cache
 
 import crystailx.scalaflagr.data.RawValue
 import crystailx.scalaflagr.json.{ Decoder, Encoder }
-import scredis.serialization.{ BytesReader, BytesWriter, Reader, Writer }
+import _root_.scredis.serialization.{ BytesReader, BytesWriter, Reader, Writer }
 
-package object redis {
+package object scredis {
 
   implicit def redisWriter[T](implicit encoder: Encoder[T]): Writer[T] = (value: T) =>
     BytesWriter.write(encoder.encode(value))

--- a/scalaflagr-cache-scredis/src/test/scala/crystailx/scalaflagr/cache/scredis/RedisCacheSpec.scala
+++ b/scalaflagr-cache-scredis/src/test/scala/crystailx/scalaflagr/cache/scredis/RedisCacheSpec.scala
@@ -1,4 +1,4 @@
-package crystailx.scalaflagr.cache.redis
+package crystailx.scalaflagr.cache.scredis
 
 import crystailx.scalaflagr.data.{ EvalResult, RawValue }
 import crystailx.scalaflagr.json.{ Decoder, Encoder }

--- a/scalaflagr-client-sttp1/src/main/scala/crystailx/scalaflagr/client/sttp/SttpHttpClient.scala
+++ b/scalaflagr-client-sttp1/src/main/scala/crystailx/scalaflagr/client/sttp/SttpHttpClient.scala
@@ -5,7 +5,8 @@ import crystailx.scalaflagr.auth.{ BasicAuthConfig, HeaderIdentifierConfig }
 import crystailx.scalaflagr.client.AuthMethod.{ Basic, JWT, NoAuth }
 import crystailx.scalaflagr.client.{ AuthMethod, HttpClient, HttpMethod, Identifier }
 import crystailx.scalaflagr.data.RawValue
-import crystailx.scalaflagr.effect.{ Functor, RichImplicitFunctor }
+import crystailx.scalaflagr.effect.Functor
+import crystailx.scalaflagr.effect.syntax.RichImplicitFunctor
 import crystailx.scalaflagr.{ FlagrConfig, FlagrRequest }
 
 case class SttpHttpClient[F[_], S](override protected val config: FlagrConfig)(implicit

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/cache/SimpleCacheKeyCreator.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/cache/SimpleCacheKeyCreator.scala
@@ -1,13 +1,14 @@
 package crystailx.scalaflagr.cache
 
-import crystailx.scalaflagr.data.RawValue
+import crystailx.scalaflagr.data.FlagrContext
 
 import scala.util.hashing.MurmurHash3
 
 trait SimpleCacheKeyCreator {
 
   implicit val simpleCacheKey: CacheKeyCreator[String] =
-    (flagKey: String, entityID: String, entityType: String, entityContext: Option[RawValue]) => {
+    (context: FlagrContext) => {
+      import context._
       val bytes = entityContext.getOrElse(Array.empty)
       val hashedContext = MurmurHash3.bytesHash(bytes)
       s"$entityType-$entityID-$flagKey-$hashedContext"

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/cache/inmemory/InMemoryCache.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/cache/inmemory/InMemoryCache.scala
@@ -15,9 +15,10 @@ case class InMemoryCache[K, F[_]]()(implicit
   private val cache: mutable.Map[K, EvalResult] = new TrieMap[K, EvalResult]()
 
   override def set(key: K, evalResult: EvalResult): F[Unit] =
-    cache
-      .put(key, evalResult)
-      .fold(throw new Exception(s"Failed to set cache key: $key"))(_ => applicative.pure(()))
+    applicative.pure {
+      cache.put(key, evalResult)
+      ()
+    }
 
   override def get(key: K): F[Option[EvalResult]] =
     applicative.pure(cache.get(key))

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/cache/nocache/package.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/cache/nocache/package.scala
@@ -1,9 +1,9 @@
 package crystailx.scalaflagr.cache
 
-import crystailx.scalaflagr.data.RawValue
+import crystailx.scalaflagr.data.FlagrContext
 
 package object nocache {
 
   implicit val emptyCacheKey: CacheKeyCreator[String] =
-    (_: String, _: String, _: String, _: Option[RawValue]) => ""
+    (_: FlagrContext) => ""
 }

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/cache/package.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/cache/package.scala
@@ -1,7 +1,7 @@
 package crystailx.scalaflagr
 
-import crystailx.scalaflagr.data.RawValue
+import crystailx.scalaflagr.data.FlagrContext
 
 package object cache extends SimpleCacheKeyCreator {
-  type CacheKeyCreator[K] = (String, String, String, Option[RawValue]) => K
+  type CacheKeyCreator[K] = FlagrContext => K
 }

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/data/FlagrContext.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/data/FlagrContext.scala
@@ -10,6 +10,14 @@ sealed trait FlagrContext {
   val entityType: String
 
   protected[scalaflagr] val entityContext: Option[RawValue]
+
+  def toEvalContext: EvalContext =
+    EvalContext(
+      Some(entityID),
+      Some(entityType),
+      entityContext,
+      flagKey = Some(flagKey)
+    )
 }
 
 case class BasicContext(

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/ApplicativeSyntax.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/ApplicativeSyntax.scala
@@ -1,0 +1,9 @@
+package crystailx.scalaflagr.effect.identity
+
+import crystailx.scalaflagr.effect.Applicative
+
+trait ApplicativeSyntax {
+
+  implicit def identityApplicative: Applicative[Identity] = new IdentityApplicative()
+
+}

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/EffectSyntax.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/EffectSyntax.scala
@@ -1,0 +1,3 @@
+package crystailx.scalaflagr.effect.identity
+
+trait EffectSyntax extends FunctorSyntax with MonadSyntax with ApplicativeSyntax {}

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/FunctorSyntax.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/FunctorSyntax.scala
@@ -1,0 +1,9 @@
+package crystailx.scalaflagr.effect.identity
+
+import crystailx.scalaflagr.effect.Functor
+
+trait FunctorSyntax {
+
+  implicit def identityFunctor: Functor[Identity] = new IdentityFunctor()
+
+}

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/IdentityApplicative.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/IdentityApplicative.scala
@@ -1,0 +1,7 @@
+package crystailx.scalaflagr.effect.identity
+
+import crystailx.scalaflagr.effect.Applicative
+
+class IdentityApplicative extends Applicative[Identity] {
+  override def pure[A](value: A): Identity[A] = value
+}

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/IdentityFunctor.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/IdentityFunctor.scala
@@ -1,0 +1,7 @@
+package crystailx.scalaflagr.effect.identity
+
+import crystailx.scalaflagr.effect.Functor
+
+class IdentityFunctor extends Functor[Identity] {
+  override def map[A, B](fa: Identity[A])(f: A => B): Identity[B] = f(fa)
+}

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/IdentityMonad.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/IdentityMonad.scala
@@ -1,0 +1,7 @@
+package crystailx.scalaflagr.effect.identity
+
+import crystailx.scalaflagr.effect.Monad
+
+class IdentityMonad extends Monad[Identity] {
+  override def flatMap[A, B](fa: Identity[A])(f: A => Identity[B]): Identity[B] = f(fa)
+}

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/MonadSyntax.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/MonadSyntax.scala
@@ -1,0 +1,9 @@
+package crystailx.scalaflagr.effect.identity
+
+import crystailx.scalaflagr.effect.Monad
+
+trait MonadSyntax {
+
+  implicit def identityMonad: Monad[Identity] = new IdentityMonad()
+
+}

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/package.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/identity/package.scala
@@ -1,0 +1,7 @@
+package crystailx.scalaflagr.effect
+
+package object identity extends EffectSyntax {
+
+  type Identity[A] = A
+
+}

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/package.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/package.scala
@@ -1,17 +1,3 @@
 package crystailx.scalaflagr
 
-package object effect extends EffectSyntax {
-
-  implicit class RichImplicitFunctor[A, F[_]](val instance: F[A]) extends AnyVal {
-
-    def map[B](f: A => B)(implicit functor: Functor[F]): F[B] =
-      functor.map(instance)(f)
-
-  }
-
-  implicit class RichImplicitMonad[A, F[_]](val instance: F[A]) extends AnyVal {
-
-    def flatMap[B](f: A => F[B])(implicit monad: Monad[F]): F[B] =
-      monad.flatMap(instance)(f)
-  }
-}
+package object effect extends EffectSyntax {}

--- a/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/syntax/package.scala
+++ b/scalaflagr-core/src/main/scala/crystailx/scalaflagr/effect/syntax/package.scala
@@ -1,0 +1,17 @@
+package crystailx.scalaflagr.effect
+
+package object syntax {
+
+  implicit class RichImplicitFunctor[A, F[_]](val instance: F[A]) extends AnyVal {
+
+    def map[B](f: A => B)(implicit functor: Functor[F]): F[B] =
+      functor.map(instance)(f)
+
+  }
+
+  implicit class RichImplicitMonad[A, F[_]](val instance: F[A]) extends AnyVal {
+
+    def flatMap[B](f: A => F[B])(implicit monad: Monad[F]): F[B] =
+      monad.flatMap(instance)(f)
+  }
+}

--- a/scalaflagr-core/src/test/scala/crystailx/scalaflagr/FlagrServiceSpec.scala
+++ b/scalaflagr-core/src/test/scala/crystailx/scalaflagr/FlagrServiceSpec.scala
@@ -3,7 +3,14 @@ package crystailx.scalaflagr
 import com.typesafe.scalalogging.LazyLogging
 import crystailx.scalaflagr.cache.{ CacheKeyCreator, Cacher }
 import crystailx.scalaflagr.client.HttpClient
-import crystailx.scalaflagr.data.{ BasicContext, EvalContext, EvalResult, RawValue }
+import crystailx.scalaflagr.data.{
+  BasicContext,
+  EntityContext,
+  EvalContext,
+  EvalResult,
+  FlagrContext,
+  RawValue
+}
 import crystailx.scalaflagr.effect.{ Applicative, Functor, Monad }
 import crystailx.scalaflagr.json.{ Decoder, Encoder }
 import org.scalatest.OptionValues.convertOptionToValuable
@@ -43,8 +50,9 @@ class FlagrServiceSpec extends FixtureAnyFlatSpec with Matchers with LazyLogging
     }
 
     implicit val cacheKeyCreator: CacheKeyCreator[String] =
-      (v1: String, v2: String, v3: String, v4: Option[RawValue]) => {
-        val key = s"$v1-$v2-$v3-${v4.map(new String(_).take(10)).getOrElse("")}"
+      (context: FlagrContext) => {
+        val EntityContext(v1, v2, v3, v4) = context
+        val key = s"$v1-$v3-$v4-${v2.map(new String(_).take(10)).getOrElse("")}"
         logger.debug(s"created key: $key")
         key
       }

--- a/scalaflagr-core/src/test/scala/crystailx/scalaflagr/TestSpec.scala
+++ b/scalaflagr-core/src/test/scala/crystailx/scalaflagr/TestSpec.scala
@@ -7,10 +7,10 @@ import scala.concurrent.Future
 
 class TestSpec extends AnyFlatSpec {
   it must "create FlagrService with default cacher and cache key creator" in {
+    import crystailx.scalaflagr.cache.nocache._
     import crystailx.scalaflagr.data._
     import crystailx.scalaflagr.effect._
     import crystailx.scalaflagr.json._
-    import crystailx.scalaflagr.cache.nocache._
 
     import scala.concurrent.ExecutionContext.Implicits.global
     implicit val encoder: crystailx.scalaflagr.json.Encoder[EvalContext] =
@@ -22,13 +22,13 @@ class TestSpec extends AnyFlatSpec {
       override def decodeSafe(value: RawValue): Either[Throwable, EvalResult] =
         Left(new Exception(""))
     }
-    val flagrClient = FlagrClient(new HttpClient[Future] {
+    val flagrClient: FlagrClient[Future] = FlagrClient(new HttpClient[Future] {
 
       override protected val config: FlagrConfig = FlagrConfig()
 
       override def send(request: FlagrRequest): Future[RawValue] = Future(Array.emptyByteArray)
     })
 
-    val service = FlagrService(flagrClient)
+    val service = FlagrService[String, Future](flagrClient)
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Breaking Changes: 
  - `cache-scredis`
  package renamed from `crystailx.scalaflagr.cache.redis` to `crystailx.scalaflagr.cache.scredis`

- New Feature:
   - `cache-scaffeine`
   Add support for caffeine cache(the async implementation is not ideal, hope someone could help in the future)
- Improvements:
  `CacheKeyCreator` now creates key from the entire `FlagrContext` response instead of instead of separated fields
- BugFix:
  The built in in memory cache fails to set cache data into due to a mis-used function call. This PR fixes it.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
